### PR TITLE
Add optional date: parameter to YMD.ymd

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,30 @@
 PATH
   remote: .
   specs:
-    ymd (0.1.0)
+    ymd (0.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    method_source (0.9.2)
-    minitest (5.11.3)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rake (13.0.1)
-    timecop (0.9.1)
+    minitest (5.27.0)
+    rake (13.3.1)
+    timecop (0.9.10)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
   minitest (~> 5.0)
-  pry
   rake (~> 13.0)
-  timecop
+  timecop (~> 0.9)
   ymd!
 
+CHECKSUMS
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  timecop (0.9.10) sha256=12ba45ce57cdcf6b1043cb6cdffa6381fd89ce10d369c28a7f6f04dc1b0cd8eb
+  ymd (0.2.0)
+
 BUNDLED WITH
-   2.0.1
+  4.0.7

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 Usage examples:
 
 ```ruby
-# default usage
+# default usage (current date)
 YMD.ymd
 # => "20191231"
 
@@ -34,6 +34,18 @@ YMD.ymd('_')
 # output date with '-' separator
 YMD.ymd('-')
 # => "2019-12-31"
+
+# with a specific Date object
+YMD.ymd(date: Date.new(2023, 12, 25))
+# => "20231225"
+
+# with a Date object and separator
+YMD.ymd('-', date: Date.new(2023, 12, 25))
+# => "2023-12-25"
+
+# works with DateTime and Time objects too
+YMD.ymd(date: DateTime.now)
+YMD.ymd('/', date: Time.now)
 ```
 
 ## Development

--- a/lib/ymd.rb
+++ b/lib/ymd.rb
@@ -2,7 +2,8 @@ require "ymd/version"
 require 'date'
 
 module YMD
-  def self.ymd(separator='')
-    DateTime.now.strftime("%Y#{separator}%m#{separator}%d")
+  def self.ymd(separator = '', date: nil)
+    target_date = date || DateTime.now
+    target_date.strftime("%Y#{separator}%m#{separator}%d")
   end
 end

--- a/lib/ymd/version.rb
+++ b/lib/ymd/version.rb
@@ -1,3 +1,3 @@
 module YMD
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/test/ymd_test.rb
+++ b/test/ymd_test.rb
@@ -12,4 +12,39 @@ class YMDTest < Minitest::Test
   def test_it_outputs_year_month_day_with_separator
     assert_equal("2019_07_14", YMD.ymd('_'))
   end
+
+  def test_with_date_object
+    date = Date.new(2023, 12, 25)
+    assert_equal("20231225", YMD.ymd(date: date))
+  end
+
+  def test_with_date_object_and_separator
+    date = Date.new(2023, 12, 25)
+    assert_equal("2023-12-25", YMD.ymd('-', date: date))
+  end
+
+  def test_with_datetime_object
+    datetime = DateTime.new(2023, 1, 15)
+    assert_equal("20230115", YMD.ymd(date: datetime))
+  end
+
+  def test_with_time_object
+    time = Time.new(2022, 6, 30)
+    assert_equal("20220630", YMD.ymd(date: time))
+  end
+
+  def test_with_nil_date_uses_current_date
+    assert_equal("20190714", YMD.ymd(date: nil))
+  end
+
+  def test_with_leap_year_date
+    date = Date.new(2024, 2, 29)
+    assert_equal("20240229", YMD.ymd(date: date))
+  end
+
+  def test_raises_on_invalid_date_type
+    assert_raises(NoMethodError) do
+      YMD.ymd(date: "2023-12-25")
+    end
+  end
 end

--- a/ymd.gemspec
+++ b/ymd.gemspec
@@ -35,9 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "timecop"
+  spec.add_development_dependency "timecop", "~> 0.9"
 end


### PR DESCRIPTION
- Format any date, not just the current date
- Remove bundler and pry dev dependencies
- Add version constraint to timecop (~> 0.9)
- Bump version to 0.2.0